### PR TITLE
feat: implement snipe-it behind nginx-proxy

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,27 @@
+# Mysql Parameters
+MYSQL_PORT_3306_TCP_ADDR=snipe-mysql
+MYSQL_ROOT_PASSWORD=YOUR_SUPER_SECRET_PASSWORD
+MYSQL_DATABASE=snipeit
+MYSQL_USER=snipeit
+MYSQL_PASSWORD=YOUR_snipeit_USER_PASSWORD
+
+# Email Parameters
+# - the hostname/IP address of your mailserver
+MAIL_PORT_587_TCP_ADDR=smtp.whatever.com
+#the port for the mailserver (probably 587, could be another)
+MAIL_PORT_587_TCP_PORT=587
+# the default from address, and from name for emails
+MAIL_ENV_FROM_ADDR=youremail@yourdomain.com
+MAIL_ENV_FROM_NAME=Your Full Email Name
+# - pick 'tls' for SMTP-over-SSL, 'tcp' for unencrypted
+MAIL_ENV_ENCRYPTION=tcp
+# SMTP username and password
+MAIL_ENV_USERNAME=your_email_username
+MAIL_ENV_PASSWORD=your_email_password
+
+# Snipe-IT Settings
+APP_ENV=production
+APP_DEBUG=false
+APP_KEY=base64:y07pi4iqrm6Js5uPW+7KRwLsvHfXSN+0TVIFO3rcOpw=
+APP_URL=https://asset.bcfranchise.com
+APP_LOCALE=en

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,7 +50,44 @@ services:
       - NGINX_PROXY_CONTAINER=nginx-proxy
     restart: always
 
+  snipe-it:
+    image: snipe/snipe-it:latest
+    container_name: snipe-it
+    hostname: asset.bcfranchise.com
+    env_file:
+    - ./.env
+    environment:
+      - CERT_NAME=asset.bcfranchise.com
+      - LETSENCRYPT_HOST=asset.bcfranchise.com
+      - SSL_POLICY=Mozilla-Intermediate
+      - VIRTUAL_HOST=asset.bcfranchise.com
+      - VIRTUAL_PORT=443
+      - VIRTUAL_PROTO=https
+    volumes:
+      - ./proxy.conf:/etc/nginx/proxy.conf
+      - ./nginx/certs/asset.bcfranchise.com.crt:/var/lib/snipeit/ssl/snipeit-ssl.crt
+      - ./nginx/certs/asset.bcfranchise.com.key:/var/lib/snipeit/ssl/snipeit-ssl.key
+      - snipesql-vol:/var/lib/mysql
+    depends_on:
+      - nginx-proxy-le
+      - snipe-mysql
+
+  snipe-mysql:
+    container_name: snipe-mysql
+    image: mysql:5.6
+    env_file:
+      - ./.env
+    volumes:
+      - snipesql-vol:/var/lib/mysql
+    command: --default-authentication-plugin=mysql_native_password
+    expose:
+      - "3306"
+
 networks:
   default:
     external:
       name: nginx-proxy
+
+volumes:
+    snipesql-vol:
+    snipe-vol:


### PR DESCRIPTION
Closes #5
https://www.bountysource.com/issues/92304070-docker-compose-implementation-of-snipe-it-with-nginx-proxy

---
Answer to https://www.bountysource.com/issues/92304070-docker-compose-implementation-of-snipe-it-with-nginx-proxy

In order to make it work you need to :
 - defined hostname in snipe-it container, otherwise internal Apache won't start properly
 - for internal snipe-it Apache to work over SSL, /var/lib/snipeit/ssl/snipeit-ssl.crt and /var/lib/snipeit/ssl/snipeit-ssl.key need to be present. Mount file generated by Let's Encrypt companion container
 - since you most probably want SSL on snipe-it Apache side, inform nginx-proxy to use HTTPS (VIRTUAL_PROTO=https) and to talk to port 443 (VIRTUAL_PORT=443)
 - In your provided nginx.conf file, I see fastcgi. It doesn't seems to be necessary (and we conflict with  VIRTUAL_PROTO=https anyway)
This ensures HTTPS from browser to nginx-proxy and from nginx-proxy to snipe-it container. Simple approch would have been to terminate HTTPS at nginx-proxy and have HTTP only to backend. Not knowing what you really need, I assumed HTTPS end-to-end.

Of course, remember to update APP_KEY (and others login/passwords) in .env file.

Otherwise, everything else works.